### PR TITLE
Fix #19 - Wrong ident.me subdomains

### DIFF
--- a/dnsupdate.sh
+++ b/dnsupdate.sh
@@ -13,7 +13,7 @@ APIHOST="https://api.domrobot.com/xmlrpc/" # API URL from inwx.de
 function get_v4_ip() {
     if [[ ! -e v4.pool ]]; then
 #        log "No IPv4 pool (v4.pool file) found. Using https://ip4.ident.me/"
-        echo $(curl -s "https://ip4.ident.me")
+        echo $(curl -s "https://v4.ident.me")
         return 0
     fi
 
@@ -33,7 +33,7 @@ function get_v6_ip() {
     if ! [ -e v6.pool ]
     then
 #        log "No IPv6 pool (v6.pool file) found. Using https://ip6.ident.me/"
-        echo $(curl -s "https://ip6.ident.me/")
+        echo $(curl -s "https://v6.ident.me/")
         return 0
     fi
 


### PR DESCRIPTION
The subdomains were changed apparently and didn't serve a valid SSL
certificate. Replaced the old names with the new ones

This should fix #19 
