### PR TITLE
Change of TTL to 300s

### DIFF
--- a/update.api
+++ b/update.api
@@ -38,7 +38,7 @@
                <member>
                   <name>ttl</name>
                   <value>
-                     <int>3600</int>
+                     <int>300</int>
                   </value>
                </member>
             </struct>


### PR DESCRIPTION
INWX allowed 300 s some time ago and it is better to have 300 s for DDNS instead of 3600 s.